### PR TITLE
Fix problems with stringifying unquoted strings, and fix parsing strings such as "1b"

### DIFF
--- a/grammar.ne
+++ b/grammar.ne
@@ -18,7 +18,7 @@ JARRAY -> "[" _ "]" {% (d) => { return { type: 'list', value: {} } } %}
 
 PAIR -> STRING _ ":" _ JVALUE {% (d) => [d[0].value, d[4]] %}
 
-STRING -> "\"" ( [^\\"] | "\\" ["bfnrt\/\\] | "\\u" [a-fA-F0-9] [a-fA-F0-9] [a-fA-F0-9] [a-fA-F0-9] ):* "\"" {% (d) => parseValue( JSON.parse(d.flat(3).join('')) ) %}
+STRING -> "\"" ( [^\\"] | "\\" ["bfnrt\/\\] | "\\u" [a-fA-F0-9] [a-fA-F0-9] [a-fA-F0-9] [a-fA-F0-9] ):* "\"" {% (d) => ({ type: 'string', value: JSON.parse(d.flat(3).join('')) }) %}
         | [^\"\'}\]:;,\s]:+ {% (d) => parseValue(d[0].join('')) %} 
 
 @{%

--- a/index.js
+++ b/index.js
@@ -22,10 +22,9 @@ function stringify ({ value, type }) {
     const str = []
     const entries = Object.entries(value)
     for (let i = 0; i < entries.length; i++) {
-      const _type = entries[i][0]
-      let _value = stringify(entries[i][1])
-      if (_type === 'string') _value = normalizeString(_value)
-      str.push(`${_type}:${_value}`)
+      const _key = normalizeString(entries[i][0])
+      const _value = stringify(entries[i][1])
+      str.push(`${_key}:${_value}`)
     }
     return `{${str.join(',')}}`
   } else if (type === 'list') {
@@ -44,7 +43,7 @@ function stringify ({ value, type }) {
 
 function normalizeString (str) {
   str = str.replace(/"/g, '\\"')
-  if (/'|{|}|\[|\]|:|;|,|\(|\)|§|=/g.test(str) || str === '') str = `"${str}"`
+  if (/[^0-9A-Za-z_\-.+]/.test(str) || str === '') str = `"${str}"`
   return str
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mojangson",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A mojangson parser written in node.js",
   "main": "index.js",
   "repository": {

--- a/test/stringify_test_data.js
+++ b/test/stringify_test_data.js
@@ -28,6 +28,6 @@ module.exports = [
   ['{id:"§a"}', '{id:"§a"}'],
   ['{id:"a="}', '{id:"a="}'],
   ['{"§akey":"§2value"}', '{"§akey":"§2value"}'],
-  ['"ሴ"', '"ሴ"']
+  ['"ሴ"', '"ሴ"'],
   ['{string:"§aTesting"}', '{string:"§aTesting"}']
 ]

--- a/test/stringify_test_data.js
+++ b/test/stringify_test_data.js
@@ -26,5 +26,8 @@ module.exports = [
   ['[I;1,2,3]', '[I;1,2,3]'],
   ['[L;1l,2l,3l]', '[L;1l,2l,3l]'],
   ['{id:"§a"}', '{id:"§a"}'],
-  ['{id:"a="}', '{id:"a="}']
+  ['{id:"a="}', '{id:"a="}'],
+  ['{"§akey":"§2value"}', '{"§akey":"§2value"}'],
+  ['"ሴ"', '"ሴ"']
+  ['{string:"§aTesting"}', '{string:"§aTesting"}']
 ]

--- a/test/stringify_test_data.js
+++ b/test/stringify_test_data.js
@@ -21,7 +21,7 @@ module.exports = [
   ['[1,2,3,]', '[1,2,3]'],
   ['[]', '[]'],
   ['["a","b;"]', '[a,"b;"]'],
-  ['{id:"minecraft:yello[w_shulker_box",Count:1b,tag:{BlockEntityTag:{CustomName:"Stacked Totems",x:0,y:0,z:0,id:"minecraft:shulker_box",Lock:""},display:{Name:"Stacked Totems"}},Damage:0s}', '{id:"minecraft:yello[w_shulker_box",Count:1b,tag:{BlockEntityTag:{CustomName:Stacked Totems,x:0,y:0,z:0,id:"minecraft:shulker_box",Lock:""},display:{Name:Stacked Totems}},Damage:0s}'],
+  ['{id:"minecraft:yello[w_shulker_box",Count:1b,tag:{BlockEntityTag:{CustomName:"Stacked Totems",x:0,y:0,z:0,id:"minecraft:shulker_box",Lock:""},display:{Name:"Stacked Totems"}},Damage:0s}', '{id:"minecraft:yello[w_shulker_box",Count:1b,tag:{BlockEntityTag:{CustomName:"Stacked Totems",x:0,y:0,z:0,id:"minecraft:shulker_box",Lock:""},display:{Name:"Stacked Totems"}},Damage:0s}'],
   ['[B;1b,2b,3b,]', '[B;1b,2b,3b]'],
   ['[I;1,2,3]', '[I;1,2,3]'],
   ['[L;1l,2l,3l]', '[L;1l,2l,3l]'],


### PR DESCRIPTION
- `normalizeString` is now used on key names in compounds,  and the check for keys named 'string' was removed
- SNBT actually uses a whitelist, so the regex for checking if a string should be quoted was changed to `/[^0-9A-Za-z_\-.+]/`
- Parsing quoted strings such as `"1b"` is now fixed