### PR TITLE
fix(grammar): support single-quoted keys in compound pairs

### DIFF
--- a/grammar.ne
+++ b/grammar.ne
@@ -18,6 +18,7 @@ JARRAY -> "[" _ "]" {% (d) => { return { type: 'list', value: {} } } %}
         | "[" _ PAIR ( _ "," _ PAIR):* (_ ","):? _ "]" {% extractArrayPair %}
 
 PAIR -> STRING _ ":" _ JVALUE {% (d) => [d[0].value, d[4]] %}
+      | SINGLE_QUOTED_STRING _ ":" _ JVALUE {% (d) => [d[0].value, d[4]] %}
 
 STRING -> "\"" ( [^\\"] | "\\" ["bfnrt\/\\] | "\\u" [a-fA-F0-9] [a-fA-F0-9] [a-fA-F0-9] [a-fA-F0-9] ):* "\"" {% (d) => parseValue( JSON.parse(d.flat(3).map(b => b.replace('\n', '\\n')).join('')) ) %}
         | [^\"\'}\]:;,\s]:+ {% (d) => parseValue(d[0].join('')) %}

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,13 @@ describe('mojangson', function () {
     ["'hello world'", { value: 'hello world', type: 'string' }],
     ["'{}'", { type: 'compound', value: {} }],
     ["'{key:value}'", { type: 'compound', value: { key: { value: 'value', type: 'string' } } }],
+    // Single-quoted keys (issue #63)
+    ["{'key':'value'}", { type: 'compound', value: { key: { value: 'value', type: 'string' } } }],
+    ["{'key':\"value\"}", { type: 'compound', value: { key: { value: 'value', type: 'string' } } }],
+    ["{'a':1,\"b\":2}", { type: 'compound', value: { a: { value: 1, type: 'int' }, b: { value: 2, type: 'int' } } }],
+    ["{'my key':'v'}", { type: 'compound', value: { 'my key': { value: 'v', type: 'string' } } }],
+    ["{'minecraft:id':'x'}", { type: 'compound', value: { 'minecraft:id': { value: 'x', type: 'string' } } }],
+    ["{'outer':{'inner':'v'}}", { type: 'compound', value: { outer: { type: 'compound', value: { inner: { value: 'v', type: 'string' } } } } }],
     // Test cases for whitespace before closing braces (issue fix)
     ['{key:value }', { type: 'compound', value: { key: { value: 'value', type: 'string' } } }],
     ['{key:value  }', { type: 'compound', value: { key: { value: 'value', type: 'string' } } }],


### PR DESCRIPTION
Related to #63

## Investigation of #63
The exact payload from the issue **parses correctly on current master** — single-quoted string *values* were already fixed by #53 (merged 2025-12-22). The reporter's stack trace (`index.js:94`, `offset: 42`, `token: { value: 's' }`) matches the **published npm package 2.0.4** (2023-06-03), which predates that fix. I verified this by installing `mojangson@2.0.4` and feeding it the issue's payload: it fails with the identical error, while master parses it fine.

So the main fix for #63 is already on master — it just hasn't been published (npm `latest` is still 2.0.4, master is 2.1.0). Publishing 2.1.0 would resolve the report.

## What this PR fixes
While verifying, I found a genuine remaining gap: single-quoted **keys** still fail, even though Minecraft SNBT allows them:

```js
mojangson.parse("{'key':'value'}")  // throws: offset 1, token "'"
```

The `PAIR` rule only accepted `STRING` as a key, and `STRING`'s unquoted branch excludes `'`. This adds a `SINGLE_QUOTED_STRING` alternative to `PAIR`, so single-quoted keys work everywhere double-quoted keys do (including keys with spaces, colons, and escaped quotes).

## Verified
- `{'key':'value'}`, `{'key':"value"}`, `{'a':1,"b":2}`, `{'my key':'v'}`, `{'minecraft:id':'x'}`, nested `{'outer':{'inner':'v'}}` all parse correctly.
- No regressions: unquoted keys, double-quoted keys, and single-quoted values all still work.
- `npm test`: 140 passing (standard lint + mocha), including 6 new single-quoted-key cases.

Note: `grammar.js` is a gitignored build artifact regenerated from `grammar.ne` via `nearleyc` (`prepublish`), so only `grammar.ne` is changed here.